### PR TITLE
REFINE: Handle "Last day" option in Monthly day picker

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,7 +32,7 @@ class MyApp extends StatelessWidget {
                       child: RRuleGenerator(
                         config: RRuleGeneratorConfig(),
                         initialRRule:
-                            'RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;UNTIL=20231211;EXDATE=20240322T000000',
+                            'RRULE:FREQ=MONTHLY;BYMONTHDAY=-1;INTERVAL=1;UNTIL=20231211;EXDATE=20240322T000000',
                         textDelegate: const EnglishRRuleTextDelegate(),
                         withExcludeDates: true,
                         onChange: print,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.8"
+    version: "0.8.9"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/src/periods/monthly.dart
+++ b/lib/src/periods/monthly.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:rrule_generator/localizations/text_delegate.dart';
+import 'package:rrule_generator/src/periods/period.dart';
 import 'package:rrule_generator/src/pickers/helpers.dart';
 import 'package:rrule_generator/src/pickers/interval.dart';
-import 'package:rrule_generator/src/periods/period.dart';
 
 import '../rrule_generator_config.dart';
 
@@ -25,9 +25,7 @@ class Monthly extends StatelessWidget implements Period {
   final dayNotifier = ValueNotifier(1);
   final intervalController = TextEditingController(text: '1');
 
-  Monthly(this.config, this.textDelegate, this.onChange, this.initialRRule,
-      this.initialDate,
-      {super.key}) {
+  Monthly(this.config, this.textDelegate, this.onChange, this.initialRRule, this.initialDate, {super.key}) {
     if (initialRRule.contains('MONTHLY')) {
       handleInitialRRule();
     } else {
@@ -41,8 +39,7 @@ class Monthly extends StatelessWidget implements Period {
     if (initialRRule.contains('BYMONTHDAY')) {
       monthTypeNotifier.value = 0;
       int dayIndex = initialRRule.indexOf('BYMONTHDAY=') + 11;
-      String day = initialRRule.substring(
-          dayIndex, dayIndex + (initialRRule.length > dayIndex + 1 ? 2 : 1));
+      String day = initialRRule.substring(dayIndex, dayIndex + (initialRRule.length > dayIndex + 1 ? 2 : 1));
       if (day.length == 1 || day[1] != ';') {
         dayNotifier.value = int.parse(day);
       } else {
@@ -53,8 +50,7 @@ class Monthly extends StatelessWidget implements Period {
         final intervalIndex = initialRRule.indexOf('INTERVAL=') + 9;
         int intervalEnd = initialRRule.indexOf(';', intervalIndex);
         intervalEnd = intervalEnd == -1 ? initialRRule.length : intervalEnd;
-        String interval = initialRRule.substring(intervalIndex,
-            intervalEnd == -1 ? initialRRule.length : intervalEnd);
+        String interval = initialRRule.substring(intervalIndex, intervalEnd == -1 ? initialRRule.length : intervalEnd);
         intervalController.text = interval;
       }
     } else {
@@ -62,8 +58,7 @@ class Monthly extends StatelessWidget implements Period {
 
       if (initialRRule.contains('BYSETPOS=')) {
         int monthDayIndex = initialRRule.indexOf('BYSETPOS=') + 9;
-        String monthDay =
-            initialRRule.substring(monthDayIndex, monthDayIndex + 1);
+        String monthDay = initialRRule.substring(monthDayIndex, monthDayIndex + 1);
 
         if (monthDay == '-') {
           monthDayNotifier.value = 4;
@@ -83,13 +78,12 @@ class Monthly extends StatelessWidget implements Period {
   @override
   String getRRule() {
     if (monthTypeNotifier.value == 0) {
-      final byMonthDay = dayNotifier.value;
+      final byMonthDay = dayNotifier.value == 32 ? -1 : dayNotifier.value; // Handle "Last day"
       final interval = int.tryParse(intervalController.text) ?? 0;
       return 'FREQ=MONTHLY;BYMONTHDAY=$byMonthDay;INTERVAL=${interval > 0 ? interval : 1}';
     } else {
-      final byDay = weekdaysShort[weekdayNotifier.value];
-      final bySetPos =
-          (monthDayNotifier.value < 4) ? monthDayNotifier.value + 1 : -1;
+      final byDay = weekdaysShort[weekdayNotifier.value]; // e.g., "MO" for Monday
+      final bySetPos = (monthDayNotifier.value < 4) ? monthDayNotifier.value + 1 : -1; // Week position
       final interval = int.tryParse(intervalController.text) ?? 0;
       return 'FREQ=MONTHLY;INTERVAL=${interval > 0 ? interval : 1};'
           'BYDAY=$byDay;BYSETPOS=$bySetPos';
@@ -152,14 +146,26 @@ class Monthly extends StatelessWidget implements Period {
                           onChange();
                         },
                         items: List.generate(
-                          31,
-                          (index) => DropdownMenuItem(
-                            value: index + 1,
-                            child: Text(
-                              '${index + 1}',
-                              style: config.textStyle,
-                            ),
-                          ),
+                          32, // One extra item for the "Last" option
+                          (index) {
+                            if (index == 31) {
+                              return DropdownMenuItem(
+                                value: 32, // Use a distinct value for "Last"
+                                child: Text(
+                                  'Last',
+                                  style: config.textStyle,
+                                ),
+                              );
+                            } else {
+                              return DropdownMenuItem(
+                                value: index + 1,
+                                child: Text(
+                                  '${index + 1}',
+                                  style: config.textStyle,
+                                ),
+                              );
+                            }
+                          },
                         ),
                       ),
                     ),
@@ -217,8 +223,7 @@ class Monthly extends StatelessWidget implements Period {
                               child: buildDropdown(
                                 child: ValueListenableBuilder(
                                   valueListenable: weekdayNotifier,
-                                  builder: (context, weekday, _) =>
-                                      DropdownButton(
+                                  builder: (context, weekday, _) => DropdownButton(
                                     isExpanded: true,
                                     value: weekday,
                                     onChanged: (newWeekday) {
@@ -229,11 +234,8 @@ class Monthly extends StatelessWidget implements Period {
                                       7,
                                       (index) {
                                         // Start with Monday as per ISO-8601 (Monday = 1, Sunday = 7)
-                                        final date =
-                                            DateTime(2023, 1, 2 + index);
-                                        final weekday =
-                                            DateFormat.EEEE(textDelegate.locale)
-                                                .format(date);
+                                        final date = DateTime(2023, 1, 2 + index);
+                                        final weekday = DateFormat.EEEE(textDelegate.locale).format(date);
                                         return DropdownMenuItem(
                                           value: index,
                                           child: Text(

--- a/lib/src/periods/monthly.dart
+++ b/lib/src/periods/monthly.dart
@@ -25,7 +25,9 @@ class Monthly extends StatelessWidget implements Period {
   final dayNotifier = ValueNotifier(1);
   final intervalController = TextEditingController(text: '1');
 
-  Monthly(this.config, this.textDelegate, this.onChange, this.initialRRule, this.initialDate, {super.key}) {
+  Monthly(this.config, this.textDelegate, this.onChange, this.initialRRule,
+      this.initialDate,
+      {super.key}) {
     if (initialRRule.contains('MONTHLY')) {
       handleInitialRRule();
     } else {
@@ -39,7 +41,8 @@ class Monthly extends StatelessWidget implements Period {
     if (initialRRule.contains('BYMONTHDAY')) {
       monthTypeNotifier.value = 0;
       int dayIndex = initialRRule.indexOf('BYMONTHDAY=') + 11;
-      String day = initialRRule.substring(dayIndex, dayIndex + (initialRRule.length > dayIndex + 1 ? 2 : 1));
+      String day = initialRRule.substring(
+          dayIndex, dayIndex + (initialRRule.length > dayIndex + 1 ? 2 : 1));
       if (day.length == 1 || day[1] != ';') {
         dayNotifier.value = int.parse(day);
       } else {
@@ -50,7 +53,8 @@ class Monthly extends StatelessWidget implements Period {
         final intervalIndex = initialRRule.indexOf('INTERVAL=') + 9;
         int intervalEnd = initialRRule.indexOf(';', intervalIndex);
         intervalEnd = intervalEnd == -1 ? initialRRule.length : intervalEnd;
-        String interval = initialRRule.substring(intervalIndex, intervalEnd == -1 ? initialRRule.length : intervalEnd);
+        String interval = initialRRule.substring(intervalIndex,
+            intervalEnd == -1 ? initialRRule.length : intervalEnd);
         intervalController.text = interval;
       }
     } else {
@@ -58,7 +62,8 @@ class Monthly extends StatelessWidget implements Period {
 
       if (initialRRule.contains('BYSETPOS=')) {
         int monthDayIndex = initialRRule.indexOf('BYSETPOS=') + 9;
-        String monthDay = initialRRule.substring(monthDayIndex, monthDayIndex + 1);
+        String monthDay =
+            initialRRule.substring(monthDayIndex, monthDayIndex + 1);
 
         if (monthDay == '-') {
           monthDayNotifier.value = 4;
@@ -78,12 +83,16 @@ class Monthly extends StatelessWidget implements Period {
   @override
   String getRRule() {
     if (monthTypeNotifier.value == 0) {
-      final byMonthDay = dayNotifier.value == 32 ? -1 : dayNotifier.value; // Handle "Last day"
+      final byMonthDay =
+          dayNotifier.value == 32 ? -1 : dayNotifier.value; // Handle "Last day"
       final interval = int.tryParse(intervalController.text) ?? 0;
       return 'FREQ=MONTHLY;BYMONTHDAY=$byMonthDay;INTERVAL=${interval > 0 ? interval : 1}';
     } else {
-      final byDay = weekdaysShort[weekdayNotifier.value]; // e.g., "MO" for Monday
-      final bySetPos = (monthDayNotifier.value < 4) ? monthDayNotifier.value + 1 : -1; // Week position
+      final byDay =
+          weekdaysShort[weekdayNotifier.value]; // e.g., "MO" for Monday
+      final bySetPos = (monthDayNotifier.value < 4)
+          ? monthDayNotifier.value + 1
+          : -1; // Week position
       final interval = int.tryParse(intervalController.text) ?? 0;
       return 'FREQ=MONTHLY;INTERVAL=${interval > 0 ? interval : 1};'
           'BYDAY=$byDay;BYSETPOS=$bySetPos';
@@ -150,9 +159,10 @@ class Monthly extends StatelessWidget implements Period {
                           (index) {
                             if (index == 31) {
                               return DropdownMenuItem(
-                                value: 32, // Use a distinct value for "Last"
+                                value: -1,
+                                // Use a distinct value for "Last"
                                 child: Text(
-                                  'Last',
+                                  textDelegate.daysInMonth.last,
                                   style: config.textStyle,
                                 ),
                               );
@@ -223,7 +233,8 @@ class Monthly extends StatelessWidget implements Period {
                               child: buildDropdown(
                                 child: ValueListenableBuilder(
                                   valueListenable: weekdayNotifier,
-                                  builder: (context, weekday, _) => DropdownButton(
+                                  builder: (context, weekday, _) =>
+                                      DropdownButton(
                                     isExpanded: true,
                                     value: weekday,
                                     onChanged: (newWeekday) {
@@ -234,8 +245,11 @@ class Monthly extends StatelessWidget implements Period {
                                       7,
                                       (index) {
                                         // Start with Monday as per ISO-8601 (Monday = 1, Sunday = 7)
-                                        final date = DateTime(2023, 1, 2 + index);
-                                        final weekday = DateFormat.EEEE(textDelegate.locale).format(date);
+                                        final date =
+                                            DateTime(2023, 1, 2 + index);
+                                        final weekday =
+                                            DateFormat.EEEE(textDelegate.locale)
+                                                .format(date);
                                         return DropdownMenuItem(
                                           value: index,
                                           child: Text(


### PR DESCRIPTION
This pull request introduces support for generating recurrence rules (RRULE) that handle the "last day of the month" scenario. The dayNotifier can now accept a value of 32, which dynamically maps to BYMONTHDAY=-1 in the resulting RRULE. Additionally, the logic for weekday-based recurrence remains unchanged. This enhancement aligns with common use cases where users may need events to recur on the last day of each month.

Changes:
Support for "Last Day of the Month":

Added a special case to check if dayNotifier.value == 32.
If true, the BYMONTHDAY parameter is set to -1, which represents the last day of the month in the RRULE format.
Dynamic Day Handling:

If dayNotifier.value is not 32, the rule generation logic uses the selected day as usual.