### PR TITLE
Fix cannot build with flutter version < 3.25

### DIFF
--- a/lib/src/pickers/helpers.dart
+++ b/lib/src/pickers/helpers.dart
@@ -52,8 +52,8 @@ Widget buildToggleItem({
               ? CupertinoSwitch(
                   value: value,
                   onChanged: onChanged,
-                  activeTrackColor: switchStyle.activeTrackColor,
-                  inactiveTrackColor: switchStyle.inactiveTrackColor,
+                  activeColor: switchStyle.activeTrackColor,
+                  trackColor: switchStyle.inactiveTrackColor,
                   thumbColor: value ? switchStyle.thumbColor : null,
                 )
               : SwitchTheme(


### PR DESCRIPTION
Hi @tkortekaas 
As your mentioned on #7
I think at this point we should still use the old property to support lower versions of flutter.
So I created this pull request. Please check it out.