### PR TITLE
fix: french dropdown recurrence options order BUG

### DIFF
--- a/lib/localizations/french.dart
+++ b/lib/localizations/french.dart
@@ -71,10 +71,10 @@ class FrenchRRuleTextDelegate implements RRuleTextDelegate {
 
   @override
   List<String> get periods => [
-        'Jamais',
         'Annuel',
         'Mensuel',
         'Hebdomadaire',
         'Quotidien',
+        'Jamais',
       ];
 }


### PR DESCRIPTION
this order of items on the list was creating problems on the dropdown list when implemented for french users.
"jamais" wich means 'never' was being associated with the 'daily' option and so on.
all the items were mixed in final order. 